### PR TITLE
Add optional attribute to black_player_id association in Game model

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,5 +1,5 @@
 class Game < ApplicationRecord
-  belongs_to :black_player, class_name: "User", foreign_key: "black_player_id"
+  belongs_to :black_player, class_name: "User", foreign_key: "black_player_id", optional: true
   belongs_to :white_player, class_name: "User", foreign_key: "white_player_id"
   has_many :pieces
 end


### PR DESCRIPTION
- Currently, we cannot create new games with only a single player in the current model associations
- Adding optional: true will skip the black_player_id validation when creating a new game