### PR TITLE
Enable capturing of pieces on game board

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,7 +13,7 @@ before_action :authenticate_user!, only: :update
       return render plain: 'Forbidden :(', status: :forbidden
     end
 
-    current_piece.move_to!(params[:piece][:file],params[:piece][:rank])
+    current_piece.move_to!(params[:piece][:file], params[:piece][:rank])
 
     if current_piece.valid?
       Move.create(

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -5,16 +5,16 @@ before_action :authenticate_user!, only: :update
     render plain: 'Forbidden', status: :forbidden if current_piece.user != current_user
     render plain: 'Not Found :(', status: :not_found if current_piece.blank?
     @piece_coord = [current_piece.file] + [current_piece.rank]
-    # puts @piece_coord.inspect
   end
 
   def update
-    # puts params.inspect
     return render_not_found if current_piece.blank?
     if current_piece.user != current_user
       return render plain: 'Forbidden :(', status: :forbidden
     end
-    current_piece.update_attributes(piece_params)
+
+    current_piece.move_to!(params[:piece][:file],params[:piece][:rank])
+
     if current_piece.valid?
       Move.create(
         piece_id: current_piece.id, 
@@ -31,7 +31,6 @@ before_action :authenticate_user!, only: :update
   private
 
   def piece_params
-    # puts params
     params.require(:piece).permit(:rank, :file)
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -57,10 +57,14 @@ class Piece < ApplicationRecord
     current_col = self.file
     current_row = self.rank
     pieces = Piece.where(file: new_col, rank: new_row, game: game, is_captured: false)
-    captured_piece = pieces.first
-    if self.color != captured_piece.color
-      captured_piece.update(is_captured: true)
-      self.update(file: new_col, rank: new_row)
+    unless pieces.empty?
+      captured_piece = pieces.first
+      if self.color != captured_piece.color
+        captured_piece.update(is_captured: true)
+      else
+        return
+      end
     end
+    self.update(file: new_col, rank: new_row)
   end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,10 +22,10 @@
             <% file = file + 1 %>
             <div class="square">
               <%= link_to "/pieces/" + "#{@game.pieces.where(
-                {file: file, rank: rank}).ids.join('')}" do %>
+                {file: file, rank: rank, is_captured: 'f' }).ids.join('')}" do %>
                 <div class=<%= "file#{file}rank#{rank}" %>>
                   <% current_game.pieces.each do |piece| %>
-                    <% if piece.rank == rank && piece.file == file %>
+                    <% if piece.rank == rank && piece.file == file && piece.is_captured == false%>
                       <%= "#{piece.color} #{piece.type}" %>
                     <% end %>
                   <% end %>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -36,7 +36,7 @@ $(function() {
             <!-- <a href='#' onclick="submitPieceMove(@current_piece.id, file, rank)"><%= "#{file}, #{rank}" %></a> -->
             <%= button_to piece_path(@current_piece), method: :patch, params: {piece: {file: file, rank: rank}} do %>
               <% current_piece.game.pieces.each do |piece| %>
-                <% if piece.rank == rank && piece.file == file && ([piece.file]+[piece.rank]) != @piece_coord %>
+                <% if piece.rank == rank && piece.file == file && ([piece.file]+[piece.rank]) != @piece_coord && piece.is_captured == false%>
                   <%= "#{piece.color} #{piece.type}" %>
                 <% end %>
               <% end %>

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -104,18 +104,18 @@ RSpec.describe Piece, type: :model do
         @piece_same_color = FactoryGirl.create(:piece, file: 5, rank: 5, game: @game, color: 'white')
       end
       
-      it "does not move the player's current piece when capturing a same color piece" do
+      it "does not move to own-piece square" do
         @current_piece.move_to!(5, 5)
 
         expect(@current_piece.file).to eq(4)
         expect(@current_piece.rank).to eq(4)
       end
 
-      it "does not capture the player's other same color piece" do
+      it "does not capture own piece" do
         @current_piece.move_to!(5, 5)
         @piece_same_color.reload
 
-        expect(@piece_same_color.is_captured).to eq(false)
+        expect(@piece_same_color.is_captured).to be false
       end
     end
   end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -66,33 +66,57 @@ RSpec.describe Piece, type: :model do
 
   describe "piece#move_to! captures piece in new square if piece is the opposite color" do
 
-    before(:each) do
-      @game = FactoryGirl.build(:game)
-      @current_piece = FactoryGirl.create(:piece, file: 4, rank: 4, game: @game, color: :black_player_id)
-      @next_square = FactoryGirl.create(:piece, file: 5, rank: 5, game: @game, color: :white_player_id)
+    context "valid case" do
+      before(:each) do
+        @game = FactoryGirl.build(:game)
+        @current_piece = FactoryGirl.create(:piece, file: 4, rank: 4, game: @game, color: :black_player_id)
+        @next_square = FactoryGirl.create(:piece, file: 5, rank: 5, game: @game, color: :white_player_id)
+      end
+
+      it "checks that there is a piece in the new square" do
+        expect(@next_square.blank?).to be false
+      end
+      it "checks that the piece in the new square belongs to the current game" do
+        expect(@next_square.game == @game).to be true
+      end
+      it "checks that the piece in the new square has not already been captured" do
+        expect(@next_square[:is_captured]).to be false
+      end
+      it "checks that the piece is the opposite color" do
+        expect(@next_square.color == @current_piece.color).to be false
+      end
+      it "captures a piece" do
+        @current_piece.move_to!(5, 5)
+        @next_square.reload
+        expect(@next_square[:is_captured]).to be true
+      end
+      it "updates the coordinates of the piece that did the capturing" do
+        @current_piece.move_to!(5, 5)
+        expect(@current_piece.file).to eq 5
+        expect(@current_piece.rank).to eq 5
+      end
     end
 
-    it "checks that there is a piece in the new square" do
-      expect(@next_square.blank?).to be false
-    end
-    it "checks that the piece in the new square belongs to the current game" do
-      expect(@next_square.game == @game).to be true
-    end
-    it "checks that the piece in the new square has not already been captured" do
-      expect(@next_square[:is_captured]).to be false
-    end
-    it "checks that the piece is the opposite color" do
-      expect(@next_square.color == @current_piece.color).to be false
-    end
-    it "captures a piece" do
-      @current_piece.move_to!(5, 5)
-      @next_square.reload
-      expect(@next_square[:is_captured]).to be true
-    end
-    it "updates the coordinates of the piece that did the capturing" do
-      @current_piece.move_to!(5, 5)
-      expect(@current_piece.file).to eq 5
-      expect(@current_piece.rank).to eq 5
+    context "invalid case" do
+      before(:each) do
+        @game = FactoryGirl.build(:game)
+        @current_piece = FactoryGirl.create(:piece, file: 4, rank: 4, game: @game, color: 'white')
+        @piece_same_color = FactoryGirl.create(:piece, file: 5, rank: 5, game: @game, color: 'white')
+      end
+      
+      it "does not move the player's current piece when capturing a same color piece" do
+        @current_piece.move_to!(5, 5)
+
+        expect(@current_piece.file).to eq(4)
+        expect(@current_piece.rank).to eq(4)
+      end
+
+      it "does not capture the player's other same color piece" do
+        @current_piece.move_to!(5, 5)
+        @piece_same_color.reload
+
+        expect(@piece_same_color.is_captured).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
- Added invalid test case for move_to! method
- Modified move_to! method to return and not update file/rank position when of the same color
- Integrated move_to! method in Pieces controller to enable capturing of pieces
- Added view logic to not display captured pieces on game board in Game and Pieces views

_Showing captured pieces on sidebar has been added to Trello_