### PR TITLE
added button for navbar items on breakpoint, and made more eye friendly

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -7,7 +7,7 @@ body {
 }
 
 a {
-  color: #d9d9d9;
+  color: #e5e5e5;
   text-shadow: 2px 2px 2px #000000;
 }
 
@@ -17,7 +17,8 @@ a:hover {
 
 .topnav {
   font-family: "Press Start 2P", Lucida Console, sans-serif;
-  font-size: 16px;
+  font-size: 14px;
+  letter-spacing: -1px;
   width: 100%;
 }
 
@@ -29,18 +30,9 @@ a:hover {
   background-size: 10%;
 }
 
-.rockslab a {
-  background-color: black;
-  color: transparent;
-  text-shadow: 2px 2px #d9d9d9;
-  -webkit-background-clip: text;
-     -moz-background-clip: text;
-          background-clip: text;
-}
-
 .topnav h1 {
   font-family: "VT323", Lucida Console, sans-serif;
-  font-size: 60px;
+  font-size: 50px;
 }
 
 .blue-box {
@@ -159,4 +151,9 @@ a:hover {
 
 .intro-box {
   text-align: center;
+}
+
+.navbar-toggler {
+  border: 1px solid #404040;
+  margin-top: 5px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,19 +33,20 @@
   </script>
 
     <!-- Banner -->
-
     <div class="container-fluid text-center topnav">
-      <div class="rockslab">
-        <h1><%= link_to 'War & Piece', root_path %></h1>
-
       <!-- Navigation Bar -->
           <nav class="navbar navbar-toggleable-md navbar">
+            <button class="navbar-toggler navbar-toggler-right navbar-light" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo02" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
+              <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="rockslab">
+            <h1><%= link_to 'War & Piece', root_path %></h1>
             <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
               <ul class="navbar-nav">
+                <li class="nav-item">
+                  <%= link_to 'Home', root_path, class: 'nav-link' %>
+                </li>
                 <% if user_signed_in? %>
-                  <li class="nav-item">
-                    <%= link_to 'Home', root_path, class: 'nav-link' %>
-                  </li>
                   <li class="nav-item">
                     <%= link_to 'My Games', games_path, class: 'nav-link' %> <!-- 'My Games' should go to the player's most recently loaded game -->
                   </li>
@@ -56,9 +57,7 @@
                     <%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'nav-link' %>
                   </li>
                 <% else %>
-                  <li class="nav-item">
-                    <%= link_to 'Home', root_path, class: 'nav-link' %>
-                  </li>
+
                   <li class="nav-item">
                     <%= link_to 'Start A Game', lobby_path, class: 'nav-link' %>
                   </li>


### PR DESCRIPTION
- In smaller window the navbar items such as "Start a Game", "Sign In" etc were disappearing completely. I added a button to access those.
 
before:
![capture1](https://user-images.githubusercontent.com/26539307/33480770-ce6417da-d689-11e7-9010-7b44d2799594.PNG)

after:
![capture7](https://user-images.githubusercontent.com/26539307/33480701-88b28b36-d689-11e7-83ce-ce3c097769d2.PNG)


- At breakpoint the text was stacking up. I made CSS changes to keep things on one line.

before:
![capture6](https://user-images.githubusercontent.com/26539307/33480863-0d13f716-d68a-11e7-9dc4-c5569326e984.PNG)

after:
![capture9](https://user-images.githubusercontent.com/26539307/33480896-2878f844-d68a-11e7-86cf-ed57056388a6.PNG)

- Removed some conflicting CSS making the text-shadow not display properly, and lightened the text color a little bit as I found the lack of contrast hard to read.

before:
![capture4](https://user-images.githubusercontent.com/26539307/33481191-5cacf07e-d68b-11e7-9d65-f7ae09071332.PNG)

after:
![capture10](https://user-images.githubusercontent.com/26539307/33481209-687bf148-d68b-11e7-9a3c-4c8241b6cbe9.PNG)

